### PR TITLE
Add missing definition of TokenRequired

### DIFF
--- a/xapers/bibtex.py
+++ b/xapers/bibtex.py
@@ -28,6 +28,7 @@ from pybtex.bibtex.utils import split_name_list
 from pybtex.database import Entry, Person
 from pybtex.database.input import bibtex as inparser
 from pybtex.database.output import bibtex as outparser
+from pybtex.scanner import TokenRequired
 
 
 def clean_bib_string(string):


### PR DESCRIPTION
Running on Debian Bullseye showed that token required was missing. This just adds the definition and was tested to work.